### PR TITLE
Remove the ability to lock cards

### DIFF
--- a/src/main/java/pcl/opensecurity/gui/CardSlot.java
+++ b/src/main/java/pcl/opensecurity/gui/CardSlot.java
@@ -16,11 +16,7 @@ public class CardSlot extends Slot {
     public boolean isItemValid(ItemStack itemstack)
     {
             if (itemstack.getItem() instanceof ItemRFIDCard || itemstack.getItem() instanceof ItemMagCard) {
-            	if(itemstack.stackTagCompound == null || !itemstack.stackTagCompound.hasKey("locked")) {
-                	return true;
-            	} else {
-            		return false;
-            	}
+		return true;
             }
             return false;
     }

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityCardWriter.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityCardWriter.java
@@ -125,10 +125,7 @@ public class TileEntityCardWriter extends TileEntityMachineBase implements Simpl
 	public boolean isItemValidForSlot(int i, ItemStack itemstack) {
 		if (i == 0) {
 			if (itemstack.getItem() instanceof ItemRFIDCard) {
-				if (itemstack.stackTagCompound == null || !itemstack.stackTagCompound.hasKey("locked")) {
-					return true;
-				}
-				return false;
+				return true;
 			}
 		}
 		return false;
@@ -186,11 +183,10 @@ public class TileEntityCardWriter extends TileEntityMachineBase implements Simpl
 		readFromNBT(packet.func_148857_g());
 	}
 
-	@Callback(doc = "function(string: data, boolean: locked):string; writes data to the card, (64 characters for RFID, or 128 for MagStripe), the rest is silently discarded, if you pass true to the 2nd argument you will not be able to erase, or rewrite data.", direct = true)
+	@Callback(doc = "function(string: data):string; writes data to the card, (64 characters for RFID, or 128 for MagStripe), the rest is silently discarded.", direct = true)
 	public Object[] write(Context context, Arguments args) {
 		String data = args.checkString(0);
 		String title = args.optString(1, "");
-		Boolean locked = args.optBoolean(2, false);
 		if (data != null) {
 			if (getStackInSlot(0) != null) {
 				for (int x = 3; x <= 12; x++) { //Loop the 9 output slots checking for a empty one
@@ -216,9 +212,6 @@ public class TileEntityCardWriter extends TileEntityMachineBase implements Simpl
 							CardWriterItemStacks[x].stackTagCompound.setString("uuid", UUID.randomUUID().toString());	
 						}
 
-						if(locked) {
-							CardWriterItemStacks[x].stackTagCompound.setBoolean("locked", locked);
-						}
 						decrStackSize(0, 1);
 						return new Object[]{true};
 					}


### PR DESCRIPTION
There doesn't seem to be any reason anyone would ever want to lock a card,
since the only thing it accomplishes is making it less useful, without making
it possible to build anything more secure. Get rid of it to keep people from
wasting their cards.