### PR TITLE
Fixing squid:UselessParenthesesCheck --   Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/pcl/opensecurity/blocks/BlockKVM.java
+++ b/src/main/java/pcl/opensecurity/blocks/BlockKVM.java
@@ -42,7 +42,7 @@ public class BlockKVM extends BlockOSBase {
 	public void onBlockPlacedBy(World par1World, int x, int y, int z, EntityLivingBase par5EntityLivingBase, ItemStack par6ItemStack) {
 		super.onBlockPlacedBy(par1World, x, y, z, par5EntityLivingBase, par6ItemStack);
 		int whichDirectionFacing = 0;
-		whichDirectionFacing = (MathHelper.floor_double(par5EntityLivingBase.rotationYaw * 4.0F / 360.0F + 0.5D) & 3);
+		whichDirectionFacing = MathHelper.floor_double(par5EntityLivingBase.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
 		switch (whichDirectionFacing) {
 		case 0:
 			whichDirectionFacing = ForgeDirection.SOUTH.ordinal();

--- a/src/main/java/pcl/opensecurity/blocks/BlockOSBase.java
+++ b/src/main/java/pcl/opensecurity/blocks/BlockOSBase.java
@@ -34,7 +34,7 @@ public class BlockOSBase extends BlockContainer {
 		} else if (par5EntityLivingBase.rotationPitch <= -70) {
 			whichDirectionFacing = 1;// up
 		} else {
-			whichDirectionFacing = (MathHelper.floor_double(par5EntityLivingBase.rotationYaw * 4.0F / 360.0F + 0.5D) & 3);
+			whichDirectionFacing = MathHelper.floor_double(par5EntityLivingBase.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
 			switch (whichDirectionFacing) {
 			case 0:
 				whichDirectionFacing = ForgeDirection.SOUTH.ordinal();

--- a/src/main/java/pcl/opensecurity/containers/EnergyTurretContainer.java
+++ b/src/main/java/pcl/opensecurity/containers/EnergyTurretContainer.java
@@ -118,7 +118,7 @@ public class EnergyTurretContainer extends Container {
 	protected boolean mergeItemStack(ItemStack stack, int start, int end, boolean backwards)
 	{
 		boolean flag1 = false;
-		int k = (backwards ? end - 1 : start);
+		int k = backwards ? end - 1 : start;
 		Slot slot;
 		ItemStack itemstack1;
 
@@ -159,7 +159,7 @@ public class EnergyTurretContainer extends Container {
 
 		if (stack.stackSize > 0)
 		{
-			k = (backwards ? end - 1 : start);
+			k = backwards ? end - 1 : start;
 
 			while (!backwards && k < end || backwards && k >= start) {
 				slot = (Slot) inventorySlots.get(k);

--- a/src/main/java/pcl/opensecurity/items/ItemRFIDCard.java
+++ b/src/main/java/pcl/opensecurity/items/ItemRFIDCard.java
@@ -39,7 +39,8 @@ public class ItemRFIDCard extends Item {
 			NBTTagCompound entityData = entity.getEntityData();
 			NBTTagCompound rfidData;
 			if (!entityData.hasKey("rfidData")) {
-				entityData.setTag("rfidData", (rfidData = new NBTTagCompound()));
+				rfidData = new NBTTagCompound();
+				entityData.setTag("rfidData", rfidData);
 			} else {
 				rfidData = entityData.getCompoundTag("rfidData");
 			}

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityDoorController.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityDoorController.java
@@ -212,7 +212,7 @@ public class TileEntityDoorController extends TileEntityMachineBase implements E
 	}
 
 	private boolean isDoorMirrored(BlockDoor door, BlockLocation loc) {
-		return ((door.func_150012_g(loc.blockAccess, loc.x, loc.y, loc.z) & 16) != 0);
+		return (door.func_150012_g(loc.blockAccess, loc.x, loc.y, loc.z) & 16) != 0;
 	}
 
 	@Callback
@@ -251,7 +251,7 @@ public class TileEntityDoorController extends TileEntityMachineBase implements E
 				// boolean isOpen = isDoorOpen(door, loc);
 				boolean isMirrored = isDoorMirrored(door, loc);
 
-				int i = (isMirrored ? -1 : 1);
+				int i = isMirrored ? -1 : 1;
 				switch (direction) {
 				case 0:
 					loc = loc.relative(0, 0, i);

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityEnergyTurret.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityEnergyTurret.java
@@ -232,7 +232,7 @@ public class TileEntityEnergyTurret extends TileEntityMachineBase implements Env
 	        double dPitch = Math.abs(pitch-setpointPitch);
 	        double dYaw = Math.abs(yaw-setpointYaw);
 	        double delta = dPitch + dYaw;
-		boolean onPoint = (delta < 0.5F);
+		boolean onPoint = delta < 0.5F;
 		return new Object[] { onPoint, delta };
 	}
 

--- a/src/main/java/pcl/opensecurity/util/BlockLocation.java
+++ b/src/main/java/pcl/opensecurity/util/BlockLocation.java
@@ -89,7 +89,7 @@ public class BlockLocation {
 	@SuppressWarnings("unchecked")
 	public <T extends TileEntity> T getTileEntity(Class<T> tileEntityClass) {
 		TileEntity tileEntity = getTileEntity();
-		return (tileEntityClass.isInstance(tileEntity) ? (T)tileEntity : null);
+		return tileEntityClass.isInstance(tileEntity) ? (T)tileEntity : null;
 	}
 	
 	/** Gets the tile entity of the block at this location.
@@ -156,7 +156,7 @@ public class BlockLocation {
 	
 	@Override
 	public int hashCode() {
-		return (blockAccess.hashCode() ^ x ^ (z << 4) ^ (y << 8)); 
+		return blockAccess.hashCode() ^ x ^ (z << 4) ^ (y << 8); 
 	}
 	
 	@Override
@@ -167,8 +167,8 @@ public class BlockLocation {
 	// Helper functions
 	
 	private String getWorldName() {
-		return (isWorld ? ("DIM=" + Integer.toString(world.provider.dimensionId))
-		                : blockAccess.toString());
+		return isWorld ? ("DIM=" + Integer.toString(world.provider.dimensionId))
+		                : blockAccess.toString();
 	}
 	
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " UselessParenthesesCheck -     Useless parentheses around expressions should be removed to prevent any misunderstanding". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Sameer Misger