### PR TITLE
Fixing squid:S1319-- Fixing squid:S1155

### DIFF
--- a/src/main/java/pcl/opensecurity/drivers/RFIDReaderCardDriver.java
+++ b/src/main/java/pcl/opensecurity/drivers/RFIDReaderCardDriver.java
@@ -2,6 +2,7 @@ package pcl.opensecurity.drivers;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import li.cil.oc.api.Network;
 import li.cil.oc.api.driver.EnvironmentHost;
@@ -103,9 +104,9 @@ public class RFIDReaderCardDriver extends DriverItem {
 		}
 
 		@SuppressWarnings({ "rawtypes" })
-		public HashMap<Integer, HashMap<String, Object>> scan(double range) {
+		public Map<Integer, HashMap<String, Object>> scan(double range) {
 			Entity entity;
-			HashMap<Integer, HashMap<String, Object>> output = new HashMap<Integer, HashMap<String, Object>>();
+			Map<Integer, HashMap<String, Object>> output = new HashMap<Integer, HashMap<String, Object>>();
 			int index = 1;
 			List e = container.world().getEntitiesWithinAABB(Entity.class, AxisAlignedBB.getBoundingBox(container.xPosition() - range, container.yPosition() - range, container.zPosition() - range, container.xPosition() + range, container.yPosition() + range, container.zPosition() + range));
 			if (!e.isEmpty()) {

--- a/src/main/java/pcl/opensecurity/entity/EntityEnergyBolt.java
+++ b/src/main/java/pcl/opensecurity/entity/EntityEnergyBolt.java
@@ -93,7 +93,7 @@ public class EntityEnergyBolt
       this.isDead = true;
     }
     List list = this.worldObj.getEntitiesWithinAABBExcludingEntity(this, this.boundingBox);
-    if (list.size() > 0)
+    if (!list.isEmpty())
     {
       ((Entity)list.get(0)).attackEntityFrom(energy, this.damage);
       this.isDead = true;

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityEntityDetector.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityEntityDetector.java
@@ -2,6 +2,7 @@ package pcl.opensecurity.tileentity;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import li.cil.oc.api.Network;
 import li.cil.oc.api.machine.Arguments;
@@ -109,12 +110,12 @@ public class TileEntityEntityDetector extends TileEntityMachineBase implements E
 	}
 
 	@SuppressWarnings({ "rawtypes" })
-	public HashMap<Integer, HashMap<String, Object>> scan(boolean players) {
+	public Map<Integer, HashMap<String, Object>> scan(boolean players) {
 		worldObj.setBlockMetadataWithNotify(this.xCoord, this.yCoord, this.zCoord, 1, 3);
 		Block block = worldObj.getBlock(this.xCoord, this.yCoord, this.zCoord);
 		worldObj.scheduleBlockUpdate(this.xCoord, this.yCoord, this.zCoord, block, 20);
 		Entity entity;
-		HashMap<Integer, HashMap<String, Object>> output = new HashMap<Integer, HashMap<String, Object>>();
+		Map<Integer, HashMap<String, Object>> output = new HashMap<Integer, HashMap<String, Object>>();
 		int index = 1;
 		List e = this.worldObj.getEntitiesWithinAABB(Entity.class, AxisAlignedBB.getBoundingBox(this.xCoord - range, this.yCoord - range, this.zCoord - range, this.xCoord + range, this.yCoord + range, this.zCoord + range));
 		if (!e.isEmpty()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1319-- Collection.isEmpty() should be used to test for emptiness,squid:S1155--Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"" information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Sameer Misger