### PR TITLE
Fixing squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/src/main/java/pcl/opensecurity/blocks/BlockKVM.java
+++ b/src/main/java/pcl/opensecurity/blocks/BlockKVM.java
@@ -56,6 +56,8 @@ public class BlockKVM extends BlockOSBase {
 		case 3:
 			whichDirectionFacing = ForgeDirection.EAST.ordinal();
 			break;
+		default:
+			break;
 		}
 		par1World.setBlockMetadataWithNotify(x, y, z, par5EntityLivingBase.isSneaking() ? whichDirectionFacing : ForgeDirection.OPPOSITES[whichDirectionFacing], 2);
 	}

--- a/src/main/java/pcl/opensecurity/blocks/BlockKeypadLock.java
+++ b/src/main/java/pcl/opensecurity/blocks/BlockKeypadLock.java
@@ -66,6 +66,8 @@ public class BlockKeypadLock extends BlockOSBase {
 			case 3: mz--; break;
 			case 4: mx++; break;
 			case 5: mx--; break;
+			default:
+				break;
 			}			
 
 		    int facing=blockAccess.getBlockMetadata(mx, my, mz);
@@ -106,7 +108,9 @@ public class BlockKeypadLock extends BlockOSBase {
 		case 2: relX=hitX*16f; break;
 		case 3: relX=(1f-hitX)*16f; break;
 		case 4: relX=(1f-hitZ)*16f; break;
-		case 5: relX=hitZ*16f; break;		
+		case 5: relX=hitZ*16f; break;
+		default:
+			break;
 		}
 		
 		//figure out what, if any, button was hit?

--- a/src/main/java/pcl/opensecurity/blocks/BlockOSBase.java
+++ b/src/main/java/pcl/opensecurity/blocks/BlockOSBase.java
@@ -48,6 +48,8 @@ public class BlockOSBase extends BlockContainer {
 			case 3:
 				whichDirectionFacing = ForgeDirection.EAST.ordinal();
 				break;
+			default:
+				break;
 			}
 		}
 		par1World.setBlockMetadataWithNotify(x, y, z, par5EntityLivingBase.isSneaking() ? whichDirectionFacing : ForgeDirection.OPPOSITES[whichDirectionFacing], 2);

--- a/src/main/java/pcl/opensecurity/gui/KVMGUI.java
+++ b/src/main/java/pcl/opensecurity/gui/KVMGUI.java
@@ -85,6 +85,8 @@ public class KVMGUI extends GuiContainer {
 		case 6:
 			this.mc.thePlayer.closeScreen(); 
 			break;
+		default:
+			break;
 		}
 	}
 

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityDoorController.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityDoorController.java
@@ -265,6 +265,8 @@ public class TileEntityDoorController extends TileEntityMachineBase implements E
 				case 3:
 					loc = loc.relative(i, 0, 0);
 					break;
+				default:
+					break;
 				}
 
 				if ((loc.getBlock() == door) && (getDoorOrientation(door, loc) == direction) && (isDoorMirrored(door, loc) != isMirrored) || worldObj.getBlock(doorCoordX, doorCoordY, doorCoordZ) instanceof BlockSecurityDoor) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck


Please let me know if you have any questions.
Sameer Misger