### PR TITLE
Fixing squid:S1126-- Return of boolean expressions should not be wrapped into an "if-then-else" statement

### DIFF
--- a/src/main/java/pcl/opensecurity/gui/CardSlot.java
+++ b/src/main/java/pcl/opensecurity/gui/CardSlot.java
@@ -16,11 +16,7 @@ public class CardSlot extends Slot {
 	@Override
 	public boolean isItemValid(ItemStack itemstack) {
 		if (itemstack.getItem() instanceof ItemRFIDCard || itemstack.getItem() instanceof ItemMagCard || itemstack.getItem() instanceof EEPROM) {
-			if (itemstack.stackTagCompound == null || !itemstack.stackTagCompound.hasKey("locked") && !itemstack.stackTagCompound.hasKey("oc:readonly")) {
-				return true;
-			} else {
-				return false;
-			}
+			return itemstack.stackTagCompound == null || !itemstack.stackTagCompound.hasKey("locked") && !itemstack.stackTagCompound.hasKey("oc:readonly");
 		}
 		return false;
 	}

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityCardWriter.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityCardWriter.java
@@ -193,11 +193,7 @@ public class TileEntityCardWriter extends TileEntityMachineBase implements Envir
 	public boolean isItemValidForSlot(int i, ItemStack itemstack) {
 		if (i == 0) {
 			if (itemstack.getItem() instanceof ItemRFIDCard || itemstack.getItem() instanceof ItemMagCard || itemstack.getItem() instanceof EEPROM) {
-				if (itemstack.stackTagCompound == null || !itemstack.stackTagCompound.hasKey("locked") && !itemstack.stackTagCompound.hasKey("oc:readonly")) {
-					return true;
-				} else {
-					return false;
-				}
+				return itemstack.stackTagCompound == null || !itemstack.stackTagCompound.hasKey("locked") && !itemstack.stackTagCompound.hasKey("oc:readonly");
 			}
 		}
 		return false;

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityKVM.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityKVM.java
@@ -53,10 +53,8 @@ public class TileEntityKVM extends TileEntitySidedEnvironment implements SidedEn
 			return true;
 		} else if (side.ordinal() == ForgeDirection.UP.ordinal() && up) {
 			return true;
-		} else if (side.ordinal() == ForgeDirection.DOWN.ordinal() && down) {
-			return true;
 		} else {
-			return false;
+			return side.ordinal() == ForgeDirection.DOWN.ordinal() && down;
 		}
 
 	}

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntitySwitchableHub.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntitySwitchableHub.java
@@ -58,10 +58,8 @@ public class TileEntitySwitchableHub extends TileEntitySidedEnvironment implemen
 			return true;
 		} else if (side.ordinal() == ForgeDirection.UP.ordinal() && up) {
 			return true;
-		} else if (side.ordinal() == ForgeDirection.DOWN.ordinal() && down) {
-			return true;
 		} else {
-			return false;
+			return side.ordinal() == ForgeDirection.DOWN.ordinal() && down;
 		}
 
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1126-- Return of boolean expressions should not be wrapped into an "if-then-else" statement" information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1126

Please let me know if you have any questions.
Sameer Misger