### PR TITLE
Fixing squid:S2325 -"private" methods that don't access instance data should be "static"

### DIFF
--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityDataBlock.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityDataBlock.java
@@ -66,7 +66,7 @@ public class TileEntityDataBlock extends TileEntityMachineBase implements Enviro
 			node.remove();
 	}
 
-	private String getComponentName() {
+	private static String getComponentName() {
 		return "os_datablock";
 	}
 

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityDoorController.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityDoorController.java
@@ -70,7 +70,7 @@ public class TileEntityDoorController extends TileEntityMachineBase implements E
 			node.remove();
 	}
 
-	private String getComponentName() {
+	private static String getComponentName() {
 		return "os_door";
 	}
 

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityEnergyTurret.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityEnergyTurret.java
@@ -439,7 +439,7 @@ public class TileEntityEnergyTurret extends TileEntityMachineBase implements Env
 			node.remove();
 	}
 
-	private String getComponentName() {
+	private static String getComponentName() {
 		return "os_energyturret";
 	}
 

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityEntityDetector.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityEntityDetector.java
@@ -49,7 +49,7 @@ public class TileEntityEntityDetector extends TileEntityMachineBase implements E
 			node.remove();
 	}
 
-	private String getComponentName() {
+	private static String getComponentName() {
 		// TODO Auto-generated method stub
 		return "os_entdetector";
 	}

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityKeypadLock.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityKeypadLock.java
@@ -75,7 +75,7 @@ public class TileEntityKeypadLock extends TileEntityMachineBase implements Envir
 			node.remove();
 	}
 
-	private String getComponentName() {
+	private static String getComponentName() {
 		return "os_keypad";
 	}
 

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityMagReader.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityMagReader.java
@@ -45,7 +45,7 @@ public class TileEntityMagReader extends TileEntityMachineBase implements Enviro
 			node.remove();
 	}
 
-	private String getComponentName() {
+	private static String getComponentName() {
 		return "os_magreader";
 	}
 

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityRFIDReader.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityRFIDReader.java
@@ -55,7 +55,7 @@ public class TileEntityRFIDReader extends TileEntityMachineBase implements Envir
 			node.remove();
 	}
 
-	private String getComponentName() {
+	private static String getComponentName() {
 		// TODO Auto-generated method stub
 		return "os_rfidreader";
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " squid:S2325 - "private" methods that don't access instance data should be "static"". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.
Sameer Misger