### PR TITLE
Fixing squid:S1197- Array designators "[]" should be on the type, not the variable

### DIFF
--- a/src/main/java/pcl/opensecurity/blocks/BlockDoorController.java
+++ b/src/main/java/pcl/opensecurity/blocks/BlockDoorController.java
@@ -162,7 +162,7 @@ public class BlockDoorController extends BlockOSBase {
 	public IIcon getIcon(IBlockAccess block, int x, int y, int z, int side) {
 		//int metadata = block.getBlockMetadata(x, y, z);
 		TileEntityDoorController te = (TileEntityDoorController) block.getTileEntity(x, y, z);
-		IIcon thisBlockTextures[] = new IIcon[6];
+		IIcon[] thisBlockTextures = new IIcon[6];
 
 		if (te.DoorControllerCamo[0] != null) {
 			te.overrideTexture(te.DoorControllerCamo[0]);

--- a/src/main/java/pcl/opensecurity/client/renderer/RenderKeypad.java
+++ b/src/main/java/pcl/opensecurity/client/renderer/RenderKeypad.java
@@ -21,16 +21,16 @@ public class RenderKeypad extends TileEntitySpecialRenderer implements IItemRend
 
 	static float texPixel=1.0f/16f;
 	
-	static ButtonState itemButtonStates[];
-	static String default_labels[] = new String[] {"1","2","3", 
+	static ButtonState[] itemButtonStates;
+	static String[] default_labels = new String[] {"1","2","3", 
 												   "4","5","6", 
 												   "7","8","9", 
 												   "*","0","#"};
-	static byte default_colors[] = new byte[] {7,7,7, 
+	static byte[] default_colors = new byte[] {7,7,7, 
 											   7,7,7, 
 											   7,7,7, 
 											   7,7,7};
-	static ButtonPosition buttons[] = null;
+	static ButtonPosition[] buttons = null;
 	static ButtonPosition display = null;
 
 	static {
@@ -246,7 +246,7 @@ public class RenderKeypad extends TileEntitySpecialRenderer implements IItemRend
 		tessellator.startDrawingQuads();
 		tessellator.setBrightness(255);
 
-		boolean pressed[] = new boolean[12];
+		boolean[] pressed = new boolean[12];
 		for(int i=0; i<pressed.length; ++i)
 			pressed[i] = keylock!=null ? keylock.buttonStates[i].isPressed(time) : false;
 
@@ -260,8 +260,8 @@ public class RenderKeypad extends TileEntitySpecialRenderer implements IItemRend
 		FontRenderer font=this.func_147498_b();
 		if (font!=null)
 		{
-			String btnLabels[] = keylock!=null ? keylock.buttonLabels : default_labels;
-			byte btnColors[] = keylock!=null ? keylock.buttonColors : default_colors;
+			String[] btnLabels = keylock!=null ? keylock.buttonLabels : default_labels;
+			byte[] btnColors = keylock!=null ? keylock.buttonColors : default_colors;
 			String fbText = keylock!=null ? keylock.displayText : "";
 			byte fbColor = keylock!=null ? keylock.displayColor : 7;
 			

--- a/src/main/java/pcl/opensecurity/tileentity/TileEntityKeypadLock.java
+++ b/src/main/java/pcl/opensecurity/tileentity/TileEntityKeypadLock.java
@@ -43,8 +43,8 @@ public class TileEntityKeypadLock extends TileEntityMachineBase implements Envir
 
 	public String data;
 	public String eventName = "keypad";
-	public String buttonLabels[] = new String[] {"1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"};
-	public byte buttonColors[] = new byte[] {7,7,7, 7,7,7, 7,7,7, 7,7,7};
+	public String[] buttonLabels = new String[] {"1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"};
+	public byte[] buttonColors = new byte[] {7,7,7, 7,7,7, 7,7,7, 7,7,7};
 	public String displayText = "";
 	public byte displayColor = 7;
 
@@ -109,7 +109,7 @@ public class TileEntityKeypadLock extends TileEntityMachineBase implements Envir
 		}
 		for(int i=0;i<12;++i)
 			buttonLabels[i] = trimString(nbt.getString("btn:"+i), MAX_LABEL_LENGTH);
-		byte colors[] = nbt.getByteArray("btn:colors");
+		byte[] colors = nbt.getByteArray("btn:colors");
 		if(colors!=null)
 			for(int i=0; i<12 && i<colors.length; ++i)
 				buttonColors[i] = colors[i];
@@ -213,7 +213,7 @@ public class TileEntityKeypadLock extends TileEntityMachineBase implements Envir
 		}		
 	}
 
-	public ButtonState buttonStates[];
+	public ButtonState[] buttonStates;
 
 	public TileEntityKeypadLock()
 	{		

--- a/src/main/java/pcl/opensecurity/util/ExtractDirectory.java
+++ b/src/main/java/pcl/opensecurity/util/ExtractDirectory.java
@@ -80,7 +80,7 @@ public class ExtractDirectory {
 					System.out.println( "  writing  " + name );
 					final InputStream is = jar.getInputStream( entry );
 					final OutputStream os = new BufferedOutputStream( new FileOutputStream( f ) );
-					final byte buffer[] = new byte[4096];
+					final byte[] buffer = new byte[4096];
 					int readCount;
 					// write contents of 'is' to 'os'
 					while( (readCount = is.read(buffer)) > 0 ) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1197- Array designators "[]" should be on the type, not the variable". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197


Please let me know if you have any questions.
Sameer Misger